### PR TITLE
Custom PseudoPriors

### DIFF
--- a/src/pytransc/pseudoprior/__init__.py
+++ b/src/pytransc/pseudoprior/__init__.py
@@ -1,0 +1,15 @@
+"""Subpackage for pseudo-prior distributions."""
+
+from .auto_pseudo import PseudoPriorOptions, build_auto_pseudo_prior
+
+
+def get_available_pseudo_priors() -> list[str]:
+    """Get a list of available pseudo-prior types."""
+    return [option.name for option in PseudoPriorOptions]
+
+
+__all__ = [
+    "build_auto_pseudo_prior",
+    "get_available_pseudo_priors",
+    "PseudoPriorOptions",
+]

--- a/src/pytransc/pseudoprior/auto_pseudo.py
+++ b/src/pytransc/pseudoprior/auto_pseudo.py
@@ -114,7 +114,7 @@ def build_auto_pseudo_prior(
     if not ensemble_per_state:
         if log_posterior_fn is None:
             raise InputError(
-                "log_posterior must be provided if ensemble_per_state is not supplied."
+                "log_posterior_fn must be provided if ensemble_per_state is not supplied."
             )
         ensemble_per_state = _generate_missing_ensembles(
             log_posterior=log_posterior_fn, sampling_args=sampling_args

--- a/src/pytransc/pseudoprior/auto_pseudo.py
+++ b/src/pytransc/pseudoprior/auto_pseudo.py
@@ -3,19 +3,17 @@
 from enum import StrEnum, auto
 from typing import Any, Protocol
 
-import numpy as np
-from scipy import stats
-from scipy.stats._multivariate import multivariate_normal_frozen
-from sklearn.mixture import GaussianMixture
-
 from ..samplers.per_state import run_mcmc_per_state
-from .exceptions import InputError
-from .types import (
+from ..utils.exceptions import InputError
+from ..utils.types import (
     FloatArray,
     MultiStateDensity,
     MultiStateDraw,
     SampleableMultiStateDensity,
 )
+from .custom import build_custom_pseudo_prior
+from .gaussian_mixture import build_gaussian_mixture_pseudo_prior
+from .mean_covariance import build_mean_covariance_pseudo_prior
 
 
 class PseudoPriorOptions(StrEnum):
@@ -24,78 +22,6 @@ class PseudoPriorOptions(StrEnum):
     GAUSSIAN_MIXTURE = auto()
     MEAN_COVARIANCE = auto()
     CUSTOM = auto()
-
-
-class GaussianMixturePseudoPrior:
-    """Class for Gaussian mixture pseudo-prior."""
-
-    def __init__(self, gaussian_mixtures: list[GaussianMixture]) -> None:
-        """
-        Initialize the Gaussian mixture pseudo-prior.
-
-        Parameters
-        ----------
-        ensemble_per_state : list of FloatArray
-            List of ensembles for each state.
-        kwargs : dict
-            Additional arguments for Gaussian mixture fitting.
-        """
-        self.gaussian_mixtures = gaussian_mixtures
-
-    def __call__(self, x: FloatArray, state: int) -> float:
-        """Evaluate the log pseudo-prior density."""
-        gmm = self.gaussian_mixtures[state]
-        return float(gmm.score(np.array([x])))
-
-    def draw_deviate(self, state: int) -> FloatArray:
-        """Draw a random deviate from the pseudo-prior for a given state."""
-        gmm = self.gaussian_mixtures[state]
-        return gmm.sample()[0][0]
-
-
-class MeanCovariancePseudoPrior:
-    """Class for mean and covariance pseudo-prior."""
-
-    def __init__(self, rv_list: list[multivariate_normal_frozen]):
-        """
-        Initialize the mean and covariance pseudo-prior.
-
-        Parameters
-        ----------
-        rv_list : list of scipy.stats._multivariate.multivariate_normal_frozen
-            List of multivariate fitted normal distributions for each state.
-        """
-        self.rv_list = rv_list
-
-    def __call__(self, x: FloatArray, state: int) -> float:
-        """Evaluate the log pseudo-prior density."""
-        rv = self.rv_list[state]
-        return rv.logpdf(x)
-
-    def draw_deviate(self, state: int) -> FloatArray:
-        """Draw a random deviate from the pseudo-prior for a given state."""
-        rv = self.rv_list[state]
-        return rv.rvs(size=1)[0]
-
-
-class CustomPseudoPrior:
-    """Class for custom pseudo-prior."""
-
-    def __init__(
-        self, log_pseudo_prior_fn: MultiStateDensity, draw_deviate_fn: MultiStateDraw
-    ) -> None:
-        """
-        Initialize the custom pseudo-prior.
-
-        Parameters
-        ----------
-        log_pseudo_prior_fn : MultiStateDensity
-            Function to evaluate the log pseudo-prior density.
-        draw_deviate_fn : MultiStateDraw
-            Function to draw a random deviate from the pseudo-prior.
-        """
-        self.__call__ = log_pseudo_prior_fn
-        self.draw_deviate = draw_deviate_fn
 
 
 class PseudoPriorBuilder(Protocol):
@@ -118,68 +44,6 @@ class PseudoPriorBuilder(Protocol):
         Returns a callable pseudo-prior function.
         """
         ...
-
-
-def build_gaussian_mixture_pseudo_prior(
-    ensemble_per_state: list[FloatArray], **kwargs: Any
-) -> GaussianMixturePseudoPrior:
-    """
-    Build a Gaussian mixture pseudo-prior function.
-
-    Args:
-        ensemble_per_state (list[FloatArray]): List of ensembles for each state.
-        **kwargs: Additional keyword arguments for Gaussian mixture fitting.
-
-    Returns:
-        list[GaussianMixture]: List of fitted Gaussian mixture models for each state.
-    """
-    gms = [
-        GaussianMixture(**kwargs).fit(state_ensemble)
-        for state_ensemble in ensemble_per_state
-    ]
-    return GaussianMixturePseudoPrior(gms)
-
-
-def build_mean_covariance_pseudo_prior(
-    ensemble_per_state: list[FloatArray],
-) -> MeanCovariancePseudoPrior:
-    """
-    Build a mean and covariance pseudo-prior function.
-
-    Args:
-        ensemble_per_state (list[FloatArray]): List of ensembles for each state.
-
-    Returns:
-        MeanCovariancePseudoPrior: Instance of MeanCovariancePseudoPrior.
-    """
-    rv_list = []
-    for state_ensemble in ensemble_per_state:
-        pseudo_covariances = np.cov(state_ensemble.T)
-        pseudo_means = np.mean(state_ensemble.T, axis=1)
-        rv = stats.multivariate_normal(mean=pseudo_means, cov=pseudo_covariances)
-        rv_list.append(rv)
-    return MeanCovariancePseudoPrior(rv_list)
-
-
-def build_custom_pseudo_prior(
-    ensemble_per_state: list[
-        FloatArray
-    ],  # this is here just to match the Protocol signature
-    *,
-    log_pseudo_prior_fn: MultiStateDensity,
-    draw_deviate_fn: MultiStateDraw,
-) -> CustomPseudoPrior:
-    """
-    Build a custom pseudo-prior function.
-
-    Args:
-        log_pseudo_prior_fn (MultiStateDensity): Function to evaluate the log pseudo-prior density.
-        draw_deviate_fn (MultiStateDraw): Function to draw a random deviate from the pseudo-prior.
-
-    Returns:
-        CustomPseudoPrior: Instance of CustomPseudoPrior.
-    """
-    return CustomPseudoPrior(log_pseudo_prior_fn, draw_deviate_fn)
 
 
 pseudo_prior_factories: dict[PseudoPriorOptions, PseudoPriorBuilder] = {

--- a/src/pytransc/pseudoprior/custom.py
+++ b/src/pytransc/pseudoprior/custom.py
@@ -1,0 +1,48 @@
+"""Module for custom pseudo-prior."""
+
+from ..utils.types import (
+    FloatArray,
+    MultiStateDensity,
+    MultiStateDraw,
+)
+
+
+class CustomPseudoPrior:
+    """Class for custom pseudo-prior."""
+
+    def __init__(
+        self, log_pseudo_prior_fn: MultiStateDensity, draw_deviate_fn: MultiStateDraw
+    ) -> None:
+        """
+        Initialize the custom pseudo-prior.
+
+        Parameters
+        ----------
+        log_pseudo_prior_fn : MultiStateDensity
+            Function to evaluate the log pseudo-prior density.
+        draw_deviate_fn : MultiStateDraw
+            Function to draw a random deviate from the pseudo-prior.
+        """
+        self.__call__ = log_pseudo_prior_fn
+        self.draw_deviate = draw_deviate_fn
+
+
+def build_custom_pseudo_prior(
+    ensemble_per_state: list[
+        FloatArray
+    ],  # this is here just to match the Protocol signature
+    *,
+    log_pseudo_prior_fn: MultiStateDensity,
+    draw_deviate_fn: MultiStateDraw,
+) -> CustomPseudoPrior:
+    """
+    Build a custom pseudo-prior function.
+
+    Args:
+        log_pseudo_prior_fn (MultiStateDensity): Function to evaluate the log pseudo-prior density.
+        draw_deviate_fn (MultiStateDraw): Function to draw a random deviate from the pseudo-prior.
+
+    Returns:
+        CustomPseudoPrior: Instance of CustomPseudoPrior.
+    """
+    return CustomPseudoPrior(log_pseudo_prior_fn, draw_deviate_fn)

--- a/src/pytransc/pseudoprior/custom.py
+++ b/src/pytransc/pseudoprior/custom.py
@@ -23,8 +23,16 @@ class CustomPseudoPrior:
         draw_deviate_fn : MultiStateDraw
             Function to draw a random deviate from the pseudo-prior.
         """
-        self.__call__ = log_pseudo_prior_fn
-        self.draw_deviate = draw_deviate_fn
+        self._log_pseudo_prior_fn = log_pseudo_prior_fn
+        self._draw_deviate_fn = draw_deviate_fn
+
+    def __call__(self, x: FloatArray, state: int) -> float:
+        """Evaluate the log pseudo-prior density."""
+        return self._log_pseudo_prior_fn(x, state)
+
+    def draw_deviate(self, state: int) -> FloatArray:
+        """Draw a random deviate from the pseudo-prior for a given state."""
+        return self._draw_deviate_fn(state)
 
 
 def build_custom_pseudo_prior(

--- a/src/pytransc/pseudoprior/custom.py
+++ b/src/pytransc/pseudoprior/custom.py
@@ -23,6 +23,11 @@ class CustomPseudoPrior:
         draw_deviate_fn : MultiStateDraw
             Function to draw a random deviate from the pseudo-prior.
         """
+        if not callable(log_pseudo_prior_fn):
+            raise TypeError("log_pseudo_prior_fn must be callable")
+        if not callable(draw_deviate_fn):
+            raise TypeError("draw_deviate_fn must be callable")
+
         self._log_pseudo_prior_fn = log_pseudo_prior_fn
         self._draw_deviate_fn = draw_deviate_fn
 

--- a/src/pytransc/pseudoprior/gaussian_mixture.py
+++ b/src/pytransc/pseudoprior/gaussian_mixture.py
@@ -1,0 +1,55 @@
+"""Module for Gaussian mixture pseudo-prior built using sklearn."""
+
+from typing import Any
+
+import numpy as np
+from sklearn.mixture import GaussianMixture
+
+from ..utils.types import FloatArray
+
+
+class GaussianMixturePseudoPrior:
+    """Class for Gaussian mixture pseudo-prior."""
+
+    def __init__(self, gaussian_mixtures: list[GaussianMixture]) -> None:
+        """
+        Initialize the Gaussian mixture pseudo-prior.
+
+        Parameters
+        ----------
+        ensemble_per_state : list of FloatArray
+            List of ensembles for each state.
+        kwargs : dict
+            Additional arguments for Gaussian mixture fitting.
+        """
+        self.gaussian_mixtures = gaussian_mixtures
+
+    def __call__(self, x: FloatArray, state: int) -> float:
+        """Evaluate the log pseudo-prior density."""
+        gmm = self.gaussian_mixtures[state]
+        return float(gmm.score(np.array([x])))
+
+    def draw_deviate(self, state: int) -> FloatArray:
+        """Draw a random deviate from the pseudo-prior for a given state."""
+        gmm = self.gaussian_mixtures[state]
+        return gmm.sample()[0][0]
+
+
+def build_gaussian_mixture_pseudo_prior(
+    ensemble_per_state: list[FloatArray], **kwargs: Any
+) -> GaussianMixturePseudoPrior:
+    """
+    Build a Gaussian mixture pseudo-prior function.
+
+    Args:
+        ensemble_per_state (list[FloatArray]): List of ensembles for each state.
+        **kwargs: Additional keyword arguments for Gaussian mixture fitting.
+
+    Returns:
+        list[GaussianMixture]: List of fitted Gaussian mixture models for each state.
+    """
+    gms = [
+        GaussianMixture(**kwargs).fit(state_ensemble)
+        for state_ensemble in ensemble_per_state
+    ]
+    return GaussianMixturePseudoPrior(gms)

--- a/src/pytransc/pseudoprior/mean_covariance.py
+++ b/src/pytransc/pseudoprior/mean_covariance.py
@@ -1,0 +1,53 @@
+"""Module for multivariate gaussian pseudo-prior built using scipy."""
+
+import numpy as np
+from scipy import stats
+from scipy.stats._multivariate import multivariate_normal_frozen
+
+from ..utils.types import FloatArray
+
+
+class MeanCovariancePseudoPrior:
+    """Class for mean and covariance pseudo-prior."""
+
+    def __init__(self, rv_list: list[multivariate_normal_frozen]):
+        """
+        Initialize the mean and covariance pseudo-prior.
+
+        Parameters
+        ----------
+        rv_list : list of scipy.stats._multivariate.multivariate_normal_frozen
+            List of multivariate fitted normal distributions for each state.
+        """
+        self.rv_list = rv_list
+
+    def __call__(self, x: FloatArray, state: int) -> float:
+        """Evaluate the log pseudo-prior density."""
+        rv = self.rv_list[state]
+        return rv.logpdf(x)
+
+    def draw_deviate(self, state: int) -> FloatArray:
+        """Draw a random deviate from the pseudo-prior for a given state."""
+        rv = self.rv_list[state]
+        return rv.rvs(size=1)[0]
+
+
+def build_mean_covariance_pseudo_prior(
+    ensemble_per_state: list[FloatArray],
+) -> MeanCovariancePseudoPrior:
+    """
+    Build a mean and covariance pseudo-prior function.
+
+    Args:
+        ensemble_per_state (list[FloatArray]): List of ensembles for each state.
+
+    Returns:
+        MeanCovariancePseudoPrior: Instance of MeanCovariancePseudoPrior.
+    """
+    rv_list = []
+    for state_ensemble in ensemble_per_state:
+        pseudo_covariances = np.cov(state_ensemble.T)
+        pseudo_means = np.mean(state_ensemble.T, axis=1)
+        rv = stats.multivariate_normal(mean=pseudo_means, cov=pseudo_covariances)
+        rv_list.append(rv)
+    return MeanCovariancePseudoPrior(rv_list)

--- a/src/pytransc/pseudoprior/mean_covariance.py
+++ b/src/pytransc/pseudoprior/mean_covariance.py
@@ -29,7 +29,7 @@ class MeanCovariancePseudoPrior:
     def draw_deviate(self, state: int) -> FloatArray:
         """Draw a random deviate from the pseudo-prior for a given state."""
         rv = self.rv_list[state]
-        return rv.rvs(size=1)[0]
+        return rv.rvs(size=1)
 
 
 def build_mean_covariance_pseudo_prior(

--- a/src/pytransc/utils/auto_pseudo.py
+++ b/src/pytransc/utils/auto_pseudo.py
@@ -10,7 +10,12 @@ from sklearn.mixture import GaussianMixture
 
 from ..samplers.per_state import run_mcmc_per_state
 from .exceptions import InputError
-from .types import FloatArray, MultiStateDensity, SampleableMultiStateDensity
+from .types import (
+    FloatArray,
+    MultiStateDensity,
+    MultiStateDraw,
+    SampleableMultiStateDensity,
+)
 
 
 class PseudoPriorOptions(StrEnum):
@@ -18,6 +23,7 @@ class PseudoPriorOptions(StrEnum):
 
     GAUSSIAN_MIXTURE = auto()
     MEAN_COVARIANCE = auto()
+    CUSTOM = auto()
 
 
 class GaussianMixturePseudoPrior:
@@ -70,6 +76,26 @@ class MeanCovariancePseudoPrior:
         """Draw a random deviate from the pseudo-prior for a given state."""
         rv = self.rv_list[state]
         return rv.rvs(size=1)[0]
+
+
+class CustomPseudoPrior:
+    """Class for custom pseudo-prior."""
+
+    def __init__(
+        self, log_pseudo_prior_fn: MultiStateDensity, draw_deviate_fn: MultiStateDraw
+    ) -> None:
+        """
+        Initialize the custom pseudo-prior.
+
+        Parameters
+        ----------
+        log_pseudo_prior_fn : MultiStateDensity
+            Function to evaluate the log pseudo-prior density.
+        draw_deviate_fn : MultiStateDraw
+            Function to draw a random deviate from the pseudo-prior.
+        """
+        self.__call__ = log_pseudo_prior_fn
+        self.draw_deviate = draw_deviate_fn
 
 
 class PseudoPriorBuilder(Protocol):
@@ -135,17 +161,41 @@ def build_mean_covariance_pseudo_prior(
     return MeanCovariancePseudoPrior(rv_list)
 
 
+def build_custom_pseudo_prior(
+    ensemble_per_state: list[
+        FloatArray
+    ],  # this is here just to match the Protocol signature
+    *,
+    log_pseudo_prior_fn: MultiStateDensity,
+    draw_deviate_fn: MultiStateDraw,
+) -> CustomPseudoPrior:
+    """
+    Build a custom pseudo-prior function.
+
+    Args:
+        log_pseudo_prior_fn (MultiStateDensity): Function to evaluate the log pseudo-prior density.
+        draw_deviate_fn (MultiStateDraw): Function to draw a random deviate from the pseudo-prior.
+
+    Returns:
+        CustomPseudoPrior: Instance of CustomPseudoPrior.
+    """
+    return CustomPseudoPrior(log_pseudo_prior_fn, draw_deviate_fn)
+
+
 pseudo_prior_factories: dict[PseudoPriorOptions, PseudoPriorBuilder] = {
     PseudoPriorOptions.GAUSSIAN_MIXTURE: build_gaussian_mixture_pseudo_prior,
     PseudoPriorOptions.MEAN_COVARIANCE: build_mean_covariance_pseudo_prior,
+    PseudoPriorOptions.CUSTOM: build_custom_pseudo_prior,
 }
 
 
 def build_auto_pseudo_prior(
     pseudo_prior_type: PseudoPriorOptions = PseudoPriorOptions.GAUSSIAN_MIXTURE,
     *,
-    ensemble_per_state: list[FloatArray] | None = None,
+    ensemble_per_state: list[FloatArray] = [],
     log_posterior: MultiStateDensity | None = None,
+    log_pseudo_prior_fn: MultiStateDensity | None = None,
+    draw_deviate_fn: MultiStateDraw | None = None,
     sampling_args: dict[str, Any] = {},
     **builder_kwargs,
 ) -> SampleableMultiStateDensity:
@@ -170,6 +220,20 @@ def build_auto_pseudo_prior(
     log_pseudo_prior : PseudoPrior
         Callable function to evaluate the log pseudo-prior at a given point and state.
     """
+    builder = pseudo_prior_factories.get(pseudo_prior_type)
+    if builder is None:
+        raise InputError(f"Unsupported pseudo_prior_type: {pseudo_prior_type}")
+
+    if pseudo_prior_type == PseudoPriorOptions.CUSTOM:
+        if log_pseudo_prior_fn is None or draw_deviate_fn is None:
+            raise InputError(
+                "For CUSTOM pseudo-prior, both log_pseudo_prior_fn and draw_deviate_fn must be provided."
+            )
+        return builder(
+            ensemble_per_state,  # not used in custom builder
+            log_pseudo_prior_fn=log_pseudo_prior_fn,
+            draw_deviate_fn=draw_deviate_fn,
+        )
 
     if ensemble_per_state is None:  # generate samples for fitting
         if log_posterior is None:
@@ -199,8 +263,6 @@ def build_auto_pseudo_prior(
             **sampling_args,
         )
 
-    log_pseudo_prior = pseudo_prior_factories[pseudo_prior_type](
-        ensemble_per_state, **builder_kwargs
-    )
+    log_pseudo_prior = builder(ensemble_per_state, **builder_kwargs)
 
     return log_pseudo_prior

--- a/src/pytransc/utils/auto_pseudo.py
+++ b/src/pytransc/utils/auto_pseudo.py
@@ -192,11 +192,11 @@ pseudo_prior_factories: dict[PseudoPriorOptions, PseudoPriorBuilder] = {
 def build_auto_pseudo_prior(
     pseudo_prior_type: PseudoPriorOptions = PseudoPriorOptions.GAUSSIAN_MIXTURE,
     *,
-    ensemble_per_state: list[FloatArray] = [],
-    log_posterior: MultiStateDensity | None = None,
+    ensemble_per_state: list[FloatArray] | None = None,
+    log_posterior_fn: MultiStateDensity | None = None,
     log_pseudo_prior_fn: MultiStateDensity | None = None,
     draw_deviate_fn: MultiStateDraw | None = None,
-    sampling_args: dict[str, Any] = {},
+    sampling_args: dict[str, Any] | None = None,
     **builder_kwargs,
 ) -> SampleableMultiStateDensity:
     """
@@ -210,8 +210,12 @@ def build_auto_pseudo_prior(
         List of posterior samples for each state. If not provided, samples will be generated using MCMC.
     log_posterior : MultiStateDensity, optional
         Function evaluating the log-posterior for each state. Required if ensemble_per_state is not provided.
+    log_pseudo_prior_fn : MultiStateDensity, optional
+        Custom function to evaluate the log pseudo-prior density. Required if pseudo_prior_type is CUSTOM.
+    draw_deviate_fn : MultiStateDraw, optional
+        Custom function to draw a random deviate from the pseudo-prior. Required if pseudo_prior_type is CUSTOM.
     sampling_args : dict, optional
-        Arguments for MCMC sampling if ensemble_per_state is not provided.
+        Arguments for MCMC sampling if ensemble_per_state is not provided.  Must include 'n_states', 'n_dims', 'n_walkers', 'n_steps', and 'pos'.
     **builder_kwargs : dict
         Additional arguments passed to the pseudo-prior builder.
 
@@ -220,9 +224,17 @@ def build_auto_pseudo_prior(
     log_pseudo_prior : PseudoPrior
         Callable function to evaluate the log pseudo-prior at a given point and state.
     """
-    builder = pseudo_prior_factories.get(pseudo_prior_type)
-    if builder is None:
-        raise InputError(f"Unsupported pseudo_prior_type: {pseudo_prior_type}")
+    try:
+        pseudo_prior_type = PseudoPriorOptions(pseudo_prior_type)
+    except ValueError:
+        raise InputError(f"Invalid pseudo_prior_type: {pseudo_prior_type}")
+
+    builder = pseudo_prior_factories[pseudo_prior_type]
+
+    if ensemble_per_state is None:
+        ensemble_per_state = []
+    if sampling_args is None:
+        sampling_args = {}
 
     if pseudo_prior_type == PseudoPriorOptions.CUSTOM:
         if log_pseudo_prior_fn is None or draw_deviate_fn is None:
@@ -235,34 +247,43 @@ def build_auto_pseudo_prior(
             draw_deviate_fn=draw_deviate_fn,
         )
 
-    if ensemble_per_state is None:  # generate samples for fitting
-        if log_posterior is None:
+    if not ensemble_per_state:
+        if log_posterior_fn is None:
             raise InputError(
                 "log_posterior must be provided if ensemble_per_state is not supplied."
             )
-        if any(
-            k not in sampling_args
-            for k in ["n_states", "n_dims", "n_walkers", "n_steps", "pos"]
-        ):
-            raise InputError(
-                "sampling_args must contain 'n_states', 'n_dims', 'n_walkers', 'n_steps', and 'pos' keys."
-            )
-
-        n_states = sampling_args.pop("n_states")
-        n_dims = sampling_args.pop("n_dims")
-        n_walkers = sampling_args.pop("n_walkers")
-        n_steps = sampling_args.pop("n_steps")
-        pos = sampling_args.pop("pos")
-        ensemble_per_state, _ = run_mcmc_per_state(
-            n_states=n_states,
-            n_dims=n_dims,
-            n_walkers=n_walkers,
-            n_steps=n_steps,
-            pos=pos,
-            log_posterior=log_posterior,
-            **sampling_args,
+        ensemble_per_state = _generate_missing_ensembles(
+            log_posterior=log_posterior_fn, sampling_args=sampling_args
         )
 
     log_pseudo_prior = builder(ensemble_per_state, **builder_kwargs)
 
     return log_pseudo_prior
+
+
+def _generate_missing_ensembles(
+    log_posterior: MultiStateDensity,
+    sampling_args: dict[str, Any],
+) -> list[FloatArray]:
+    if any(
+        k not in sampling_args
+        for k in ["n_states", "n_dims", "n_walkers", "n_steps", "pos"]
+    ):
+        raise InputError(
+            "sampling_args must contain 'n_states', 'n_dims', 'n_walkers', 'n_steps', and 'pos' keys."
+        )
+
+    n_states = sampling_args.pop("n_states")
+    n_dims = sampling_args.pop("n_dims")
+    n_walkers = sampling_args.pop("n_walkers")
+    n_steps = sampling_args.pop("n_steps")
+    pos = sampling_args.pop("pos")
+    return run_mcmc_per_state(
+        n_states=n_states,
+        n_dims=n_dims,
+        n_walkers=n_walkers,
+        n_steps=n_steps,
+        pos=pos,
+        log_posterior=log_posterior,
+        **sampling_args,
+    )[0]  # return only the ensembles

--- a/src/pytransc/utils/auto_pseudo.py
+++ b/src/pytransc/utils/auto_pseudo.py
@@ -5,6 +5,7 @@ from typing import Any, Protocol
 
 import numpy as np
 from scipy import stats
+from scipy.stats._multivariate import multivariate_normal_frozen
 from sklearn.mixture import GaussianMixture
 
 from ..samplers.per_state import run_mcmc_per_state
@@ -12,11 +13,63 @@ from .exceptions import InputError
 from .types import FloatArray, MultiStateDensity, SampleableMultiStateDensity
 
 
-class PseudoPriorBuilders(StrEnum):
+class PseudoPriorOptions(StrEnum):
     """Enum for available pseudo-prior builders."""
 
     GAUSSIAN_MIXTURE = auto()
     MEAN_COVARIANCE = auto()
+
+
+class GaussianMixturePseudoPrior:
+    """Class for Gaussian mixture pseudo-prior."""
+
+    def __init__(self, gaussian_mixtures: list[GaussianMixture]) -> None:
+        """
+        Initialize the Gaussian mixture pseudo-prior.
+
+        Parameters
+        ----------
+        ensemble_per_state : list of FloatArray
+            List of ensembles for each state.
+        kwargs : dict
+            Additional arguments for Gaussian mixture fitting.
+        """
+        self.gaussian_mixtures = gaussian_mixtures
+
+    def __call__(self, x: FloatArray, state: int) -> float:
+        """Evaluate the log pseudo-prior density."""
+        gmm = self.gaussian_mixtures[state]
+        return float(gmm.score(np.array([x])))
+
+    def draw_deviate(self, state: int) -> FloatArray:
+        """Draw a random deviate from the pseudo-prior for a given state."""
+        gmm = self.gaussian_mixtures[state]
+        return gmm.sample()[0][0]
+
+
+class MeanCovariancePseudoPrior:
+    """Class for mean and covariance pseudo-prior."""
+
+    def __init__(self, rv_list: list[multivariate_normal_frozen]):
+        """
+        Initialize the mean and covariance pseudo-prior.
+
+        Parameters
+        ----------
+        rv_list : list of scipy.stats._multivariate.multivariate_normal_frozen
+            List of multivariate fitted normal distributions for each state.
+        """
+        self.rv_list = rv_list
+
+    def __call__(self, x: FloatArray, state: int) -> float:
+        """Evaluate the log pseudo-prior density."""
+        rv = self.rv_list[state]
+        return rv.logpdf(x)
+
+    def draw_deviate(self, state: int) -> FloatArray:
+        """Draw a random deviate from the pseudo-prior for a given state."""
+        rv = self.rv_list[state]
+        return rv.rvs(size=1)[0]
 
 
 class PseudoPriorBuilder(Protocol):
@@ -41,79 +94,61 @@ class PseudoPriorBuilder(Protocol):
         ...
 
 
-class GaussianMixturePseudoPrior:
-    """Class for Gaussian mixture pseudo-prior."""
+def build_gaussian_mixture_pseudo_prior(
+    ensemble_per_state: list[FloatArray], **kwargs: Any
+) -> GaussianMixturePseudoPrior:
+    """
+    Build a Gaussian mixture pseudo-prior function.
 
-    def __init__(self, ensemble_per_state: list[FloatArray], **kwargs):
-        """
-        Initialize the Gaussian mixture pseudo-prior.
+    Args:
+        ensemble_per_state (list[FloatArray]): List of ensembles for each state.
+        **kwargs: Additional keyword arguments for Gaussian mixture fitting.
 
-        Parameters
-        ----------
-        ensemble_per_state : list of FloatArray
-            List of ensembles for each state.
-        kwargs : dict
-            Additional arguments for Gaussian mixture fitting.
-        """
-        self.gaussian_mixtures = [
-            GaussianMixture(**kwargs).fit(ens) for ens in ensemble_per_state
-        ]
-
-    def __call__(self, x: FloatArray, state: int) -> float:
-        """Evaluate the log pseudo-prior density."""
-        gmm = self.gaussian_mixtures[state]
-        return float(gmm.score([x]))
-
-    def draw_deviate(self, state: int) -> FloatArray:
-        """Draw a random deviate from the pseudo-prior for a given state."""
-        gmm = self.gaussian_mixtures[state]
-        return gmm.sample()[0][0]
+    Returns:
+        list[GaussianMixture]: List of fitted Gaussian mixture models for each state.
+    """
+    gms = [
+        GaussianMixture(**kwargs).fit(state_ensemble)
+        for state_ensemble in ensemble_per_state
+    ]
+    return GaussianMixturePseudoPrior(gms)
 
 
-class MeanCovariancePseudoPrior:
-    """Class for mean and covariance pseudo-prior."""
+def build_mean_covariance_pseudo_prior(
+    ensemble_per_state: list[FloatArray],
+) -> MeanCovariancePseudoPrior:
+    """
+    Build a mean and covariance pseudo-prior function.
 
-    def __init__(self, ensemble_per_state: list[FloatArray]):
-        """
-        Initialize the mean and covariance pseudo-prior.
+    Args:
+        ensemble_per_state (list[FloatArray]): List of ensembles for each state.
 
-        Parameters
-        ----------
-        ensemble_per_state : list of FloatArray
-            List of ensembles for each state.
-        """
-        self.rv_list = []
-        for state_ensemble in ensemble_per_state:
-            pseudo_covariances_ = np.cov(state_ensemble.T)
-            pseudo_means_ = np.mean(state_ensemble.T, axis=1)
-            rv = stats.multivariate_normal(mean=pseudo_means_, cov=pseudo_covariances_)
-            self.rv_list.append(rv)
-
-    def __call__(self, x: FloatArray, state: int) -> float:
-        """Evaluate the log pseudo-prior density."""
-        rv = self.rv_list[state]
-        return rv.logpdf(x)
-
-    def draw_deviate(self, state: int) -> FloatArray:
-        """Draw a random deviate from the pseudo-prior for a given state."""
-        rv = self.rv_list[state]
-        return rv.rvs(size=1)[0]
+    Returns:
+        MeanCovariancePseudoPrior: Instance of MeanCovariancePseudoPrior.
+    """
+    rv_list = []
+    for state_ensemble in ensemble_per_state:
+        pseudo_covariances = np.cov(state_ensemble.T)
+        pseudo_means = np.mean(state_ensemble.T, axis=1)
+        rv = stats.multivariate_normal(mean=pseudo_means, cov=pseudo_covariances)
+        rv_list.append(rv)
+    return MeanCovariancePseudoPrior(rv_list)
 
 
-pseudo_prior_factories: dict[PseudoPriorBuilders, PseudoPriorBuilder] = {
-    PseudoPriorBuilders.GAUSSIAN_MIXTURE: GaussianMixturePseudoPrior,
-    PseudoPriorBuilders.MEAN_COVARIANCE: MeanCovariancePseudoPrior,
+pseudo_prior_factories: dict[PseudoPriorOptions, PseudoPriorBuilder] = {
+    PseudoPriorOptions.GAUSSIAN_MIXTURE: build_gaussian_mixture_pseudo_prior,
+    PseudoPriorOptions.MEAN_COVARIANCE: build_mean_covariance_pseudo_prior,
 }
 
 
 def build_auto_pseudo_prior(
-    pseudo_prior_type: PseudoPriorBuilders = PseudoPriorBuilders.GAUSSIAN_MIXTURE,
+    pseudo_prior_type: PseudoPriorOptions = PseudoPriorOptions.GAUSSIAN_MIXTURE,
     *,
     ensemble_per_state: list[FloatArray] | None = None,
     log_posterior: MultiStateDensity | None = None,
     sampling_args: dict[str, Any] = {},
     **builder_kwargs,
-):
+) -> SampleableMultiStateDensity:
     """
     Build an automatic pseudo-prior function using a specified builder.
 

--- a/src/pytransc/utils/types.py
+++ b/src/pytransc/utils/types.py
@@ -68,7 +68,7 @@ class MultiStateDraw(Protocol):
         ...
 
 
-class SampleableMultiStateDensity(MultiStateDensity, MultiStateDraw, Protocol):
+class SampleableMultiStateDensity(Protocol):
     """Protocol for multi-state density functions that support sampling.
 
     This protocol extends MultiStateDensity to include the ability to
@@ -76,6 +76,9 @@ class SampleableMultiStateDensity(MultiStateDensity, MultiStateDraw, Protocol):
     used by the state-jump sampler for drawing from pseudo-priors
     when proposing between-state moves.
     """
+
+    __call__: MultiStateDensity
+    draw_deviate: MultiStateDraw
 
 
 class ProposableMultiStateDensity(MultiStateDensity, Protocol):

--- a/src/pytransc/utils/types.py
+++ b/src/pytransc/utils/types.py
@@ -48,16 +48,10 @@ class MultiStateDensity(Protocol):
         ...
 
 
-class SampleableMultiStateDensity(MultiStateDensity, Protocol):
-    """Protocol for multi-state density functions that support sampling.
+class MultiStateDraw(Protocol):
+    """Protocol for multi-state density functions that support drawing."""
 
-    This protocol extends MultiStateDensity to include the ability to
-    generate random samples from the distribution. This is primarily
-    used by the state-jump sampler for drawing from pseudo-priors
-    when proposing between-state moves.
-    """
-
-    def draw_deviate(self, state: int) -> FloatArray:
+    def __call__(self, state: int) -> FloatArray:
         """Draw a random sample from the distribution for the given state.
 
         Parameters
@@ -72,6 +66,16 @@ class SampleableMultiStateDensity(MultiStateDensity, Protocol):
             Shape should match the parameter space dimension for that state.
         """
         ...
+
+
+class SampleableMultiStateDensity(MultiStateDensity, MultiStateDraw, Protocol):
+    """Protocol for multi-state density functions that support sampling.
+
+    This protocol extends MultiStateDensity to include the ability to
+    generate random samples from the distribution. This is primarily
+    used by the state-jump sampler for drawing from pseudo-priors
+    when proposing between-state moves.
+    """
 
 
 class ProposableMultiStateDensity(MultiStateDensity, Protocol):

--- a/tests/test_pytransc/test_pseudoprior/conftest.py
+++ b/tests/test_pytransc/test_pseudoprior/conftest.py
@@ -1,0 +1,17 @@
+"""Common fixtures for testing pseudopriors."""
+
+import numpy as np
+import pytest
+from scipy.stats import multivariate_normal
+
+from pytransc.utils.types import FloatArray
+
+
+@pytest.fixture
+def ensemble_per_state() -> list[FloatArray]:
+    """Fixture for ensemble per state."""
+    mus = [0.0, 1.0]
+    covs = [1, 2]
+    state_rvs = [multivariate_normal(mean=mu, cov=cov) for mu, cov in zip(mus, covs)]
+
+    return [state_rv.rvs(size=50_000)[..., np.newaxis] for state_rv in state_rvs]

--- a/tests/test_pytransc/test_pseudoprior/conftest.py
+++ b/tests/test_pytransc/test_pseudoprior/conftest.py
@@ -15,3 +15,15 @@ def ensemble_per_state() -> list[FloatArray]:
     state_rvs = [multivariate_normal(mean=mu, cov=cov) for mu, cov in zip(mus, covs)]
 
     return [state_rv.rvs(size=50_000)[..., np.newaxis] for state_rv in state_rvs]
+
+
+@pytest.fixture
+def log_pseudo_prior_fn(x: FloatArray, state: int) -> float:
+    """Example log pseudo-prior function."""
+    return state * x.sum()
+
+
+@pytest.fixture
+def draw_deviate_fn(state: int) -> FloatArray:
+    """Example draw deviate function."""
+    return np.ones(state)

--- a/tests/test_pytransc/test_pseudoprior/conftest.py
+++ b/tests/test_pytransc/test_pseudoprior/conftest.py
@@ -18,12 +18,15 @@ def ensemble_per_state() -> list[FloatArray]:
 
 
 @pytest.fixture
-def log_pseudo_prior_fn(x: FloatArray, state: int) -> float:
-    """Example log pseudo-prior function."""
-    return state * x.sum()
-
+def log_pseudo_prior_fn():
+    """Example log pseudo-prior function factory."""
+    def _log_pseudo_prior_fn(x: FloatArray, state: int) -> float:
+        return state * x.sum()
+    return _log_pseudo_prior_fn
 
 @pytest.fixture
-def draw_deviate_fn(state: int) -> FloatArray:
-    """Example draw deviate function."""
-    return np.ones(state)
+def draw_deviate_fn():
+    """Example draw deviate function factory."""
+    def _draw_deviate_fn(state: int) -> FloatArray:
+        return np.ones(state)
+    return _draw_deviate_fn

--- a/tests/test_pytransc/test_pseudoprior/test_auto_pseudo.py
+++ b/tests/test_pytransc/test_pseudoprior/test_auto_pseudo.py
@@ -1,0 +1,105 @@
+"""Testing the user-facing auto build function for pseudo-priors."""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from pytransc.pseudoprior import build_auto_pseudo_prior
+from pytransc.pseudoprior.auto_pseudo import PseudoPriorOptions
+from pytransc.utils.exceptions import InputError
+from pytransc.utils.types import FloatArray
+
+
+def test_auto_pseudo_prior_invalid_method() -> None:
+    """Test that invalid method raises ValueError."""
+    with pytest.raises(InputError, match="Invalid pseudo_prior_type"):
+        build_auto_pseudo_prior("invalid_method")
+
+
+def test_passing_pseudo_type_as_string(ensemble_per_state: list[FloatArray]) -> None:
+    """Test that passing pseudo_prior_type as string works."""
+    pseudo = build_auto_pseudo_prior(
+        pseudo_prior_type="mean_covariance", ensemble_per_state=ensemble_per_state
+    )
+    assert pseudo.__class__.__name__ == "MeanCovariancePseudoPrior"
+
+
+def test_custom_missing_functions() -> None:
+    """Test error raised when insufficient functions provided for custom method."""
+
+    with pytest.raises(
+        InputError,
+        match="both log_pseudo_prior_fn and draw_deviate_fn must be provided",
+    ):
+        build_auto_pseudo_prior(
+            pseudo_prior_type=PseudoPriorOptions.CUSTOM,
+            log_pseudo_prior_fn=None,
+            draw_deviate_fn=None,
+        )
+
+
+def test_no_ensemble_no_log_posterior() -> None:
+    """Test error raised when no ensemble and no log posterior provided."""
+
+    with pytest.raises(
+        InputError,
+        match="log_posterior must be provided if ensemble_per_state is not supplied",
+    ):
+        build_auto_pseudo_prior(
+            pseudo_prior_type=PseudoPriorOptions.MEAN_COVARIANCE,
+            ensemble_per_state=None,
+            log_posterior_fn=None,
+        )
+
+
+def test_no_ensemble_incomplete_sampling_args() -> None:
+    """Test error raised when no ensemble and incomplete sampling args provided."""
+
+    with pytest.raises(
+        InputError,
+        match="sampling_args must contain 'n_states', 'n_dims', 'n_walkers', 'n_steps', and 'pos' keys",
+    ):
+        build_auto_pseudo_prior(
+            pseudo_prior_type=PseudoPriorOptions.MEAN_COVARIANCE,
+            ensemble_per_state=None,
+            log_posterior_fn=lambda x, state: -0.5 * (x**2).sum(),
+            sampling_args={"n_states": 2, "n_dims": 1},  # incomplete
+        )
+
+
+def test_ensembles_generated() -> None:
+    """Test that ensembles are generated when not provided."""
+
+    rng = np.random.default_rng(42)
+
+    with patch(
+        "pytransc.pseudoprior.auto_pseudo._generate_missing_ensembles"
+    ) as mock_generate:
+        mock_generate.return_value = [
+            rng.normal(size=(100, 1)),
+            rng.normal(size=(50, 3)),
+        ]
+
+        def _log_posterior_fn(x: np.ndarray, state: int) -> float:
+            return -0.5 * (x**2).sum()
+
+        sampling_args = {
+            "n_states": 2,
+            "n_dims": 1,
+            "n_walkers": 10,
+            "n_steps": 50,
+            "pos": [[1.0], [2.0]],
+            "random_state": 42,
+        }
+
+        _ = build_auto_pseudo_prior(
+            pseudo_prior_type=PseudoPriorOptions.MEAN_COVARIANCE,
+            ensemble_per_state=None,
+            log_posterior_fn=_log_posterior_fn,
+            sampling_args=sampling_args,
+        )
+
+        mock_generate.assert_called_once_with(
+            log_posterior=_log_posterior_fn, sampling_args=sampling_args
+        )

--- a/tests/test_pytransc/test_pseudoprior/test_custom.py
+++ b/tests/test_pytransc/test_pseudoprior/test_custom.py
@@ -1,0 +1,35 @@
+"""Tests for custom pseudo-prior."""
+
+import numpy as np
+
+from pytransc.utils.types import FloatArray
+
+
+def log_pseudo_prior_fn(x: FloatArray, state: int) -> float:
+    """Example log pseudo-prior function."""
+    return state * x.sum()
+
+
+def draw_deviate_fn(state: int) -> FloatArray:
+    """Example draw deviate function."""
+    return np.ones(state)
+
+
+def test_custom_pseudo_prior():
+    """Test custom pseudo-prior."""
+    from pytransc.pseudoprior.custom import build_custom_pseudo_prior
+
+    custom_pseudo = build_custom_pseudo_prior(
+        ensemble_per_state=[],  # not used in custom builder
+        log_pseudo_prior_fn=log_pseudo_prior_fn,
+        draw_deviate_fn=draw_deviate_fn,
+    )
+
+    x = np.array([1.0, 2.0, 3.0])
+    state = 2
+
+    log_density = custom_pseudo(x, state)
+    deviate = custom_pseudo.draw_deviate(state)
+
+    assert log_density == state * x.sum()
+    assert np.array_equal(deviate, np.ones(state))

--- a/tests/test_pytransc/test_pseudoprior/test_custom.py
+++ b/tests/test_pytransc/test_pseudoprior/test_custom.py
@@ -4,21 +4,13 @@ import numpy as np
 import pytest
 
 from pytransc.pseudoprior.custom import CustomPseudoPrior, build_custom_pseudo_prior
-from pytransc.utils.types import FloatArray
-
-
-def log_pseudo_prior_fn(x: FloatArray, state: int) -> float:
-    """Example log pseudo-prior function."""
-    return state * x.sum()
-
-
-def draw_deviate_fn(state: int) -> FloatArray:
-    """Example draw deviate function."""
-    return np.ones(state)
+from pytransc.utils.types import MultiStateDensity, MultiStateDraw
 
 
 @pytest.fixture
-def custom_pseudo() -> CustomPseudoPrior:
+def custom_pseudo(
+    log_pseudo_prior_fn: MultiStateDensity, draw_deviate_fn: MultiStateDraw
+) -> CustomPseudoPrior:
     """Fixture providing a custom pseudo-prior."""
 
     return build_custom_pseudo_prior(
@@ -30,6 +22,8 @@ def custom_pseudo() -> CustomPseudoPrior:
 
 def test_custom_pseudo_prior_valid_initialization(
     custom_pseudo: CustomPseudoPrior,
+    log_pseudo_prior_fn: MultiStateDensity,
+    draw_deviate_fn: MultiStateDraw,
 ) -> None:
     """Test custom pseudo-prior initialization."""
 
@@ -38,7 +32,9 @@ def test_custom_pseudo_prior_valid_initialization(
     assert custom_pseudo._draw_deviate_fn is draw_deviate_fn
 
 
-def test_custom_pseudo_prior_invalid_initialization() -> None:
+def test_custom_pseudo_prior_invalid_initialization(
+    log_pseudo_prior_fn: MultiStateDensity, draw_deviate_fn: MultiStateDraw
+) -> None:
     """Test custom pseudo-prior invalid initialization."""
 
     with pytest.raises(TypeError, match="log_pseudo_prior_fn must be callable"):

--- a/tests/test_pytransc/test_pseudoprior/test_custom.py
+++ b/tests/test_pytransc/test_pseudoprior/test_custom.py
@@ -1,7 +1,9 @@
 """Tests for custom pseudo-prior."""
 
 import numpy as np
+import pytest
 
+from pytransc.pseudoprior.custom import CustomPseudoPrior, build_custom_pseudo_prior
 from pytransc.utils.types import FloatArray
 
 
@@ -15,21 +17,61 @@ def draw_deviate_fn(state: int) -> FloatArray:
     return np.ones(state)
 
 
-def test_custom_pseudo_prior():
-    """Test custom pseudo-prior."""
-    from pytransc.pseudoprior.custom import build_custom_pseudo_prior
+@pytest.fixture
+def custom_pseudo() -> CustomPseudoPrior:
+    """Fixture providing a custom pseudo-prior."""
 
-    custom_pseudo = build_custom_pseudo_prior(
-        ensemble_per_state=[],  # not used in custom builder
+    return build_custom_pseudo_prior(
+        ensemble_per_state=[],
         log_pseudo_prior_fn=log_pseudo_prior_fn,
         draw_deviate_fn=draw_deviate_fn,
     )
+
+
+def test_custom_pseudo_prior_valid_initialization(
+    custom_pseudo: CustomPseudoPrior,
+) -> None:
+    """Test custom pseudo-prior initialization."""
+
+    assert isinstance(custom_pseudo, CustomPseudoPrior)
+    assert custom_pseudo._log_pseudo_prior_fn is log_pseudo_prior_fn
+    assert custom_pseudo._draw_deviate_fn is draw_deviate_fn
+
+
+def test_custom_pseudo_prior_invalid_initialization() -> None:
+    """Test custom pseudo-prior invalid initialization."""
+
+    with pytest.raises(TypeError, match="log_pseudo_prior_fn must be callable"):
+        build_custom_pseudo_prior(
+            ensemble_per_state=[],
+            log_pseudo_prior_fn="not_a_function",  # type: ignore
+            draw_deviate_fn=draw_deviate_fn,
+        )
+
+    with pytest.raises(TypeError, match="draw_deviate_fn must be callable"):
+        build_custom_pseudo_prior(
+            ensemble_per_state=[],
+            log_pseudo_prior_fn=log_pseudo_prior_fn,
+            draw_deviate_fn="not_a_function",  # type: ignore
+        )
+
+    with pytest.raises(TypeError, match="missing 2 required keyword-only arguments"):
+        build_custom_pseudo_prior(ensemble_per_state=[])  # type: ignore
+
+
+def test_custom_pseudo_prior_log_density(custom_pseudo: CustomPseudoPrior) -> None:
+    """Test custom pseudo-prior."""
 
     x = np.array([1.0, 2.0, 3.0])
     state = 2
 
     log_density = custom_pseudo(x, state)
-    deviate = custom_pseudo.draw_deviate(state)
+    assert log_density == 12.0
 
-    assert log_density == state * x.sum()
+
+def test_custom_pseudo_prior_deviate(custom_pseudo: CustomPseudoPrior) -> None:
+    """Test custom pseudo-prior draw deviate."""
+
+    state = 2
+    deviate = custom_pseudo.draw_deviate(state)
     assert np.array_equal(deviate, np.ones(state))

--- a/tests/test_pytransc/test_pseudoprior/test_gaussian_mixture.py
+++ b/tests/test_pytransc/test_pseudoprior/test_gaussian_mixture.py
@@ -2,32 +2,22 @@
 
 import numpy as np
 import pytest
-from scipy.stats import multivariate_normal
 from sklearn.mixture import GaussianMixture
 
 from pytransc.pseudoprior.gaussian_mixture import (
     GaussianMixturePseudoPrior,
     build_gaussian_mixture_pseudo_prior,
 )
+from pytransc.utils.types import FloatArray
 
 
 @pytest.fixture
-def ensemble_per_state() -> list[np.ndarray]:
-    """Fixture for ensemble per state."""
-    mus = [0.0, 1.0]
-    covs = [1, 2]
-    state_rvs = [multivariate_normal(mean=mu, cov=cov) for mu, cov in zip(mus, covs)]
-
-    return [state_rv.rvs(size=50_000)[..., np.newaxis] for state_rv in state_rvs]
-
-
-@pytest.fixture
-def gm_pseudo(ensemble_per_state: list[np.ndarray]) -> GaussianMixturePseudoPrior:
+def gm_pseudo(ensemble_per_state: list[FloatArray]) -> GaussianMixturePseudoPrior:
     """Fixture for Gaussian Mixture pseudo-prior."""
     return build_gaussian_mixture_pseudo_prior(ensemble_per_state)
 
 
-def test_kwargs_handling(ensemble_per_state: list[np.ndarray]) -> None:
+def test_kwargs_handling(ensemble_per_state: list[FloatArray]) -> None:
     """Test that kwargs are correctly passed to GaussianMixture."""
     with pytest.raises(TypeError):
         # n_components should be an integer
@@ -45,7 +35,7 @@ def test_kwargs_handling(ensemble_per_state: list[np.ndarray]) -> None:
         assert gmm.reg_covar == 1
 
 
-def test_gaussian_mixture_pseudo_prior(ensemble_per_state: list[np.ndarray]) -> None:
+def test_gaussian_mixture_pseudo_prior(ensemble_per_state: list[FloatArray]) -> None:
     """Test Gaussian Mixture pseudo-priors are properly fitted."""
 
     gm_pseudo = build_gaussian_mixture_pseudo_prior(ensemble_per_state)

--- a/tests/test_pytransc/test_pseudoprior/test_gaussian_mixture.py
+++ b/tests/test_pytransc/test_pseudoprior/test_gaussian_mixture.py
@@ -1,0 +1,82 @@
+"""Tests for the Gaussian Mixture pseudo-prior."""
+
+import numpy as np
+import pytest
+from scipy.stats import multivariate_normal
+from sklearn.mixture import GaussianMixture
+
+from pytransc.pseudoprior.gaussian_mixture import (
+    GaussianMixturePseudoPrior,
+    build_gaussian_mixture_pseudo_prior,
+)
+
+
+@pytest.fixture
+def ensemble_per_state() -> list[np.ndarray]:
+    """Fixture for ensemble per state."""
+    mus = [0.0, 1.0]
+    covs = [1, 2]
+    state_rvs = [multivariate_normal(mean=mu, cov=cov) for mu, cov in zip(mus, covs)]
+
+    return [state_rv.rvs(size=50_000)[..., np.newaxis] for state_rv in state_rvs]
+
+
+@pytest.fixture
+def gm_pseudo(ensemble_per_state: list[np.ndarray]) -> GaussianMixturePseudoPrior:
+    """Fixture for Gaussian Mixture pseudo-prior."""
+    return build_gaussian_mixture_pseudo_prior(ensemble_per_state)
+
+
+def test_kwargs_handling(ensemble_per_state: list[np.ndarray]) -> None:
+    """Test that kwargs are correctly passed to GaussianMixture."""
+    with pytest.raises(TypeError):
+        # n_components should be an integer
+        build_gaussian_mixture_pseudo_prior(ensemble_per_state, n_components="invalid")
+
+    with pytest.raises(ValueError):
+        # n_components should be positive
+        build_gaussian_mixture_pseudo_prior(ensemble_per_state, n_components=0)
+
+    gm_pseudo_prior = build_gaussian_mixture_pseudo_prior(
+        ensemble_per_state, n_components=2, reg_covar=1
+    )
+    for gmm in gm_pseudo_prior.gaussian_mixtures:
+        assert gmm.n_components == 2
+        assert gmm.reg_covar == 1
+
+
+def test_gaussian_mixture_pseudo_prior(ensemble_per_state: list[np.ndarray]) -> None:
+    """Test Gaussian Mixture pseudo-priors are properly fitted."""
+
+    gm_pseudo = build_gaussian_mixture_pseudo_prior(ensemble_per_state)
+    for gmm, ensemble in zip(gm_pseudo.gaussian_mixtures, ensemble_per_state):
+        assert isinstance(gmm, GaussianMixture)
+        assert np.isclose(gmm.means_[0], np.mean(ensemble))
+        assert np.isclose(gmm.covariances_[0], np.var(ensemble))
+
+
+def test_gaussian_mixture_pseudo_prior_log_density(
+    gm_pseudo: GaussianMixturePseudoPrior,
+) -> None:
+    """Test the log density evaluation of Gaussian Mixture pseudo-prior."""
+
+    def gaussian_logpdf(x: float, mean: float, cov: float) -> float:
+        """Manually compute the log pdf of a univariate Gaussian."""
+        return -0.5 * np.log(2 * np.pi * cov) - 0.5 * (x - mean) ** 2 / cov
+
+    for state, gmm in enumerate(gm_pseudo.gaussian_mixtures):
+        log_density_at_mean = gm_pseudo(gmm.means_[0], state)
+        assert np.isclose(
+            log_density_at_mean,
+            gaussian_logpdf(gmm.means_[0], gmm.means_[0], gmm.covariances_[0]),
+        )
+
+
+def test_gaussian_mixture_pseudo_prior_deviate(
+    gm_pseudo: GaussianMixturePseudoPrior,
+) -> None:
+    """Test the sampling from the Gaussian Mixture pseudo-prior."""
+    for state, gmm in enumerate(gm_pseudo.gaussian_mixtures):
+        deviates = np.array([gm_pseudo.draw_deviate(state) for _ in range(1_000)])
+        assert np.isclose(np.mean(deviates), gmm.means_[0], atol=0.1)
+        assert np.isclose(np.var(deviates), gmm.covariances_[0], atol=0.1)

--- a/tests/test_pytransc/test_pseudoprior/test_mean_covariance.py
+++ b/tests/test_pytransc/test_pseudoprior/test_mean_covariance.py
@@ -1,0 +1,32 @@
+"""Tests for the mean-covariance pseudo-prior."""
+
+import numpy as np
+from scipy.stats import multivariate_normal
+
+from pytransc.pseudoprior.mean_covariance import build_mean_covariance_pseudo_prior
+
+
+def gaussian_logpdf(x: float, mean: float, cov: float) -> float:
+    """Manually compute the log pdf of a univariate Gaussian."""
+    return -0.5 * np.log(2 * np.pi * cov) - 0.5 * (x - mean) ** 2 / cov
+
+
+def test_mean_covariance_pseudo_prior():
+    """Test mean-covariance pseudo-prior."""
+    mus = [0.0, 1.0]
+    covs = [1, 2]
+    state_rvs = [multivariate_normal(mean=mu, cov=cov) for mu, cov in zip(mus, covs)]
+
+    ensemble_per_state = [
+        state_rv.rvs(size=50_000)[..., np.newaxis] for state_rv in state_rvs
+    ]
+
+    mean_cov_pseudo = build_mean_covariance_pseudo_prior(ensemble_per_state)
+
+    for state, (mu, cov) in enumerate(zip(mus, covs)):
+        log_density_at_mean = mean_cov_pseudo(np.array([mu]), state)
+        assert np.isclose(log_density_at_mean, gaussian_logpdf(mu, mu, cov), atol=0.01)
+
+        deviates = np.array([mean_cov_pseudo.draw_deviate(state) for _ in range(1_000)])
+        assert np.isclose(np.mean(deviates), mu, atol=0.1)
+        assert np.isclose(np.var(deviates), cov, atol=0.1)

--- a/tests/test_pytransc/test_pseudoprior/test_mean_covariance.py
+++ b/tests/test_pytransc/test_pseudoprior/test_mean_covariance.py
@@ -1,31 +1,46 @@
 """Tests for the mean-covariance pseudo-prior."""
 
 import numpy as np
-from scipy.stats import multivariate_normal
+import pytest
 
-from pytransc.pseudoprior.mean_covariance import build_mean_covariance_pseudo_prior
+from pytransc.pseudoprior.mean_covariance import (
+    MeanCovariancePseudoPrior,
+    build_mean_covariance_pseudo_prior,
+)
+from pytransc.utils.types import FloatArray
 
 
-def gaussian_logpdf(x: float, mean: float, cov: float) -> float:
-    """Manually compute the log pdf of a univariate Gaussian."""
-    return -0.5 * np.log(2 * np.pi * cov) - 0.5 * (x - mean) ** 2 / cov
+@pytest.fixture
+def mean_cov_pseudo(ensemble_per_state: list[FloatArray]) -> MeanCovariancePseudoPrior:
+    """Fixture providing a mean-covariance pseudo-prior."""
+    return build_mean_covariance_pseudo_prior(ensemble_per_state)
 
 
-def test_mean_covariance_pseudo_prior():
-    """Test mean-covariance pseudo-prior."""
-    mus = [0.0, 1.0]
-    covs = [1, 2]
-    state_rvs = [multivariate_normal(mean=mu, cov=cov) for mu, cov in zip(mus, covs)]
+def test_mean_covariance_pseudo_prior_log_density(
+    mean_cov_pseudo: MeanCovariancePseudoPrior,
+) -> None:
+    """Test mean-covariance pseudo-prior log density evaluation."""
 
-    ensemble_per_state = [
-        state_rv.rvs(size=50_000)[..., np.newaxis] for state_rv in state_rvs
-    ]
+    def gaussian_logpdf(x: float, mean: float, cov: float) -> float:
+        """Manually compute the log pdf of a univariate Gaussian."""
+        return -0.5 * np.log(2 * np.pi * cov) - 0.5 * (x - mean) ** 2 / cov
 
-    mean_cov_pseudo = build_mean_covariance_pseudo_prior(ensemble_per_state)
+    for state, rv in enumerate(mean_cov_pseudo.rv_list):
+        mu = rv.mean[0]
+        cov = rv.cov[0, 0]
 
-    for state, (mu, cov) in enumerate(zip(mus, covs)):
         log_density_at_mean = mean_cov_pseudo(np.array([mu]), state)
         assert np.isclose(log_density_at_mean, gaussian_logpdf(mu, mu, cov), atol=0.01)
+
+
+def test_mean_covariance_pseudo_prior_draw_deviate(
+    mean_cov_pseudo: MeanCovariancePseudoPrior,
+) -> None:
+    """Test mean-covariance pseudo-prior draw deviate."""
+
+    for state, rv in enumerate(mean_cov_pseudo.rv_list):
+        mu = rv.mean[0]
+        cov = rv.cov[0, 0]
 
         deviates = np.array([mean_cov_pseudo.draw_deviate(state) for _ in range(1_000)])
         assert np.isclose(np.mean(deviates), mu, atol=0.1)


### PR DESCRIPTION
Adds a new `PseudoPriorOptions.CUSTOM`.  Additional arguments to `build_auto_pseudo_prior` so the user can pass in functions to evaluate the density and draw samples from the distribution.  This is done in such a way that ensembles aren't even necessary.

All the PseudoPrior functionality has been moved out of `utils`.

Extensive tests for the pseudo priors added.